### PR TITLE
$_ env variable fixed. unset & export updated

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -61,6 +61,7 @@ char		*find_env_value(t_list **head, char *key);
 void		delete_env_variable(t_list **head, char *key);
 void		free_env(void *env, size_t size);
 int			update_underscore(t_list **env, char *path_cmd);
+char		*last_arg(t_command *cmd);
 
 /* ------------------------------------------------------------------------- */
 
@@ -125,7 +126,7 @@ void		dup_fd(int *fd);
  * Builtins
  */
 int			echo_builtin(t_command *cmd);
-int			pwd_builtin(t_command *cmd);
+int			pwd_builtin(t_list **env, t_command *cmd);
 
 int			exit_builtin(t_command *cmd);
 int			exit_arg(t_command *cmd, size_t i);

--- a/srcs/builtins_1.c
+++ b/srcs/builtins_1.c
@@ -101,26 +101,15 @@ int		update_pwd(t_list **env)
 */
 //cmd->command[1] = expand_tilde(env, cmd->command[1]);
 
-void	update_cd_underscore(t_list **env, char **args)
-{
-	int	i;
-
-	i = 0;
-	while (args[i])
-		i++;
-	if (i > 0)
-		update_underscore(env, args[i - 1]);
-}
-
 int		cd_builtin(t_list **env, t_command *cmd)
 {
 	if (!(cmd->command[1]))
-		if (!(cmd->command[1] = ft_strjoin("~", "")))
-			return (-1);
+		if (!(cmd->command[1] = ft_strjoin("~", "")))//!!! -> the array is not 
+			return (-1);//anymore NULL terminated ?! check this
 	if (!(cmd->command[1][0]))
 		return (0);
 	cmd->command[1] = expand_tilde_and_exceptions(env, cmd->command[1], cmd);
-	update_cd_underscore(env, cmd->command);
+	update_underscore(env, last_arg(cmd));
 	if ((chdir(cmd->command[1])) == -1)
 	{
 		if (cmd->command[2])

--- a/srcs/builtins_2.c
+++ b/srcs/builtins_2.c
@@ -38,10 +38,11 @@ int			echo_builtin(t_command *cmd)
 	return (0);
 }
 
-int		pwd_builtin(t_command *cmd)
+int		pwd_builtin(t_list **env, t_command *cmd)
 {
 	char	*stored;
 
+	update_underscore(env, last_arg(cmd));
 	stored = getcwd(NULL, 0);
 	ft_putstr_fd(stored, cmd->fd[1]);
 	ft_putchar_fd('\n', cmd->fd[1]);

--- a/srcs/builtins_3.c
+++ b/srcs/builtins_3.c
@@ -49,16 +49,18 @@ static char		**alpha_order_string(t_list **env)
 	return (env_tab);
 }
 
-void	update_export_underscore(t_list **env, char *arg)
+void	update_export_underscore(t_list **env, t_command *cmd)
 {
+	char	*last;
 	char	*needle;
 	int		len;
 
-	if (!(needle = ft_strrchr(arg, '=')))
-		len = ft_strlen(arg);
+	last = last_arg(cmd);
+	if (!(needle = ft_strchr(last, '=')))
+		len = ft_strlen(last);
 	else
-		len = needle - arg;
-	if (!(needle = ft_substr(arg, 0, len)))
+		len = needle - last;
+	if (!(needle = ft_substr(last, 0, len)))
 		return ;
 	update_underscore(env, needle);
 	free(needle);
@@ -83,16 +85,15 @@ int			export_builtin(t_list **env, t_command *cmd)
 	char	**envir;
 	int		i;
 
+	update_export_underscore(env, cmd);
+	i = 0;
 	if (cmd->command[0] && cmd->command[1])
-	{
-		update_export_underscore(env, cmd->command[1]);
-		add_env_variable(env, cmd->command[1]);
-	}
+		while (cmd->command[++i])
+			add_env_variable(env, cmd->command[i]);
 	else if (cmd->command[0] && !cmd->command[1])
 	{
 		if (!(envir = alpha_order_string(env)))
 			return (-1);
-		update_underscore(env, cmd->command[0]);
 		i = -1;
 		while (envir[++i] && envir[i + 1])
 			print_envir(cmd, envir, i);
@@ -103,12 +104,12 @@ int			export_builtin(t_list **env, t_command *cmd)
 
 int			unset_builtin(t_list **env, t_command *cmd)
 {
+	int		i;
+
+	i = 0;
+	update_underscore(env, last_arg(cmd));
 	if (cmd->command[0] && cmd->command[1])
-	{
-		update_underscore(env, cmd->command[1]);
-		delete_env_variable(env, cmd->command[1]);
-	}
-	else if (cmd->command[0] && !cmd->command[1])
-		update_underscore(env, cmd->command[0]);
+		while (cmd->command[++i])
+			delete_env_variable(env, cmd->command[i]);
 	return (0);
 }

--- a/srcs/environment.c
+++ b/srcs/environment.c
@@ -4,7 +4,7 @@ static int	create_env_struct(char *keyvalue, t_env *env)
 {
 	char	*needle;
 
-	if (!(needle = ft_strrchr(keyvalue, '=')))
+	if (!(needle = ft_strchr(keyvalue, '=')))
 		return (0);
 	env->key = ft_substr(keyvalue, 0, needle - keyvalue);
 	env->value = ft_strdup(needle + 1);

--- a/srcs/executable_builtin.c
+++ b/srcs/executable_builtin.c
@@ -1,15 +1,3 @@
-/* ************************************************************************** */
-/*                                                                            */
-/*                                                        :::      ::::::::   */
-/*   executable_builtin.c                               :+:      :+:    :+:   */
-/*                                                    +:+ +:+         +:+     */
-/*   By: jfreitas <jfreitas@student.s19.be>         +#+  +:+       +#+        */
-/*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2021/02/08 19:16:50 by jfreitas          #+#    #+#             */
-/*   Updated: 2021/03/02 23:46:31 by jle-corr         ###   ########.fr       */
-/*                                                                            */
-/* ************************************************************************** */
-
 #include "minishell.h"
 
 /*
@@ -79,6 +67,18 @@ void	printthis(t_command *cmd, char *path_to_cmd)/////////delete
 	fflush(stdout);
 }/////////delete
 
+char	*last_arg(t_command *cmd)
+{
+	int		i;
+
+	i = 0;
+	while (cmd->command[i])
+		i++;
+	if (i > 0)
+		i -= 1;
+	return (cmd->command[i]);
+}
+
 int		update_underscore(t_list **env, char *path_cmd)
 {
 	char	*keyvalue;
@@ -103,7 +103,7 @@ int		executable_builtin(t_list **env, t_command *cmd)
 	signal(SIGQUIT, ctrl_back_slash_handler_quit);
 	env_tab = env_list_to_tab(*env);
 	printthis(cmd, path_to_cmd);
-	update_underscore(env, path_to_cmd);
+	update_underscore(env, last_arg(cmd));
 	if ((fork_pid = fork()) == -1)
 		exit(errno);
 	else if (fork_pid == 0)

--- a/srcs/main_loop.c
+++ b/srcs/main_loop.c
@@ -4,13 +4,11 @@
 int		execute_command(t_list **env, t_command *cmd)
 {
 	int		ret;
-	char	*builtin;
 	
-	builtin = NULL;
 	if (ft_strcmp(cmd->command[0], "echo") == 0)
 		ret = echo_builtin(cmd);
-	else if (ft_strcmp(cmd->command[0], "pwd") == 0 && (builtin = "pwd"))
-		ret = pwd_builtin(cmd);
+	else if (ft_strcmp(cmd->command[0], "pwd") == 0)
+		ret = pwd_builtin(env, cmd);
 	else if (ft_strcmp(cmd->command[0], "exit") == 0)
 		ret = exit_builtin(cmd);
 	else if (ft_strcmp(cmd->command[0], "cd") == 0)
@@ -28,8 +26,6 @@ int		execute_command(t_list **env, t_command *cmd)
 		ret = test_builtin(env, cmd);
 	else
 		ret = executable_builtin(env, cmd);
-	if (builtin)
-		update_underscore(env, builtin);
 	return (ret);
 }
 


### PR DESCRIPTION
$_ display now the last arg used (even if it's wrong arg).
!! the "command not found" error must be returned until the end to fit in this variable.

unset & export can now export or unset multiples arguments.
unset behavior fixed (strchr instead of strrchr in create_env_struct for needle)